### PR TITLE
fix: add yarn 3.0.x compatibility check and use Node LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
 ## How it works
 
 - Detects package manager (yarn or npm) from lock file
-- Uses Node LTS with npm 11+ for OIDC support
+- Uses Node LTS with the latest npm version for OIDC support
 - Configures git with the GitHub actor
 - Installs dependencies (`yarn install --immutable` or `npm ci`)
 - Runs release-it with the appropriate flags

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: |
         if [ -f "yarn.lock" ] && [ -f ".yarnrc.yml" ]; then
-          YARN_PATH=$(grep "yarnPath:" .yarnrc.yml | sed 's/.*yarn-\([0-9.]*\)\.cjs/\1/')
+          YARN_PATH=$(grep "yarnPath:" .yarnrc.yml | sed 's/.*yarn-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\.cjs/\1/')
           if [[ "$YARN_PATH" =~ ^3\.0\. ]]; then
             echo "::error::Yarn 3.0.x has a known bug causing ERR_STREAM_PREMATURE_CLOSE with Node 20+."
             echo "::error::Please upgrade yarn by running: yarn set version 3.8.7"


### PR DESCRIPTION
## Summary
- Add pre-flight check for yarn 3.0.x which has `ERR_STREAM_PREMATURE_CLOSE` bug with Node 20+
- Fail early with helpful error message pointing to fix (`yarn set version 3.8.7`)
- Document known issue and solution in README
- Use Node LTS instead of fixed version

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)