### PR TITLE
fix: fetch tags before updating major version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
           VERSION="${{ steps.next.outputs.version }}"
           MAJOR_TAG="v${VERSION#v}" && MAJOR_TAG="v${MAJOR_TAG%%.*}"
 
+          # Fetch the new tag created by gh release
+          git fetch origin --tags
+
           # Delete existing major tag if it exists
           git tag -d "${MAJOR_TAG}" 2>/dev/null || true
           git push origin ":refs/tags/${MAJOR_TAG}" 2>/dev/null || true


### PR DESCRIPTION
## Summary
Fix release workflow failing to update major version tag.

## Type of Change
- [x] Bug fix (patch)

## Testing
- [ ] Tested in a workflow after merge

## Release Notes
Fix release workflow to fetch tags after gh release creates them remotely.

---
Closes #