### PR TITLE
fix: update dependabot commit message format for commitlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "chore"
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
 
@@ -14,6 +15,7 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "chore"
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
Fix Dependabot commit messages to pass commitlint validation.

## Type of Change
- [x] Bug fix (patch)

## Testing
- [ ] Dependabot PRs will be recreated with correct format after merge

## Release Notes
Dependabot commits now use `chore(deps): bump ...` format.

---
Closes #