### PR TITLE
fix: allow sentence-case in commit subjects for dependabot

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Allow sentence-case for Dependabot commits (e.g., "Bump actions/checkout")
+    'subject-case': [2, 'always', ['lower-case', 'sentence-case']],
+  },
 };


### PR DESCRIPTION
## Summary
Allow sentence-case in commit subjects so Dependabot's "Bump" commits pass commitlint.

## Type of Change
- [x] Bug fix (patch)

---
Closes #