### PR TITLE
feat: add automatic release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,19 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version type'
-        required: true
+      increment:
+        description: 'Version increment (leave blank for auto from commits)'
+        required: false
+        default: ''
         type: choice
-        default: 'patch'
         options:
+          - ''
           - patch
           - minor
           - major
@@ -20,81 +25,40 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install release-it
+        run: npm install -g release-it @release-it/conventional-changelog
 
       - name: Configure git
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-      - name: Get current version
-        id: current
+      - name: Release
         run: |
-          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' || echo "v0.0.0")
-          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
-          echo "Current version: ${LATEST_TAG}"
+          npx release-it --ci ${{ inputs.increment }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Calculate next version
-        id: next
-        run: |
-          CURRENT="${{ steps.current.outputs.tag }}"
-          # Remove 'v' prefix
-          VERSION="${CURRENT#v}"
-
-          # Parse semver
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-
-          # Set defaults if parsing failed
-          MAJOR=${MAJOR:-0}
-          MINOR=${MINOR:-0}
-          PATCH=${PATCH:-0}
-
-          # Increment based on input
-          case "${{ inputs.version }}" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
-
-          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
-          echo "Next version: ${NEW_VERSION}"
-
-      - name: Create release
-        run: |
-          gh release create ${{ steps.next.outputs.version }} \
-            --title "${{ steps.next.outputs.version }}" \
-            --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update major version tag
         run: |
-          VERSION="${{ steps.next.outputs.version }}"
-          MAJOR_TAG="v${VERSION#v}" && MAJOR_TAG="v${MAJOR_TAG%%.*}"
-
-          # Fetch the new tag created by gh release
-          git fetch origin --tags
+          # Get the latest tag just created
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          MAJOR_TAG="v${LATEST_TAG#v}" && MAJOR_TAG="v${MAJOR_TAG%%.*}"
 
           # Delete existing major tag if it exists
           git tag -d "${MAJOR_TAG}" 2>/dev/null || true
           git push origin ":refs/tags/${MAJOR_TAG}" 2>/dev/null || true
 
           # Create new major tag pointing to this release
-          git tag "${MAJOR_TAG}" "${{ steps.next.outputs.version }}"
+          git tag "${MAJOR_TAG}" "${LATEST_TAG}"
           git push origin "${MAJOR_TAG}"
 
-          echo "Updated ${MAJOR_TAG} to point to ${{ steps.next.outputs.version }}"
+          echo "Updated ${MAJOR_TAG} to point to ${LATEST_TAG}"

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,17 @@
+{
+  "git": {
+    "commitMessage": "chore: release v${version}"
+  },
+  "github": {
+    "release": true
+  },
+  "npm": {
+    "publish": false
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "infile": "CHANGELOG.md",
+      "preset": "conventionalcommits"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add push trigger for `action.yml` changes to automatically release
- Use release-it with conventional commits for automatic versioning
- Add `.release-it.json` config (npm publish disabled since this is a GitHub Action)

## How it works

1. Push to main with changes to `action.yml` triggers release
2. release-it reads conventional commit messages to determine version bump
3. Creates GitHub release with auto-generated notes
4. Updates major version tag (e.g., `v1`) to point to latest

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)