### PR TITLE
fix: handle packages without lockfiles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,10 @@ runs:
       run: |
         if [ -f "yarn.lock" ]; then
           yarn install --immutable
-        else
+        elif [ -f "package-lock.json" ]; then
           npm ci
+        else
+          npm install
         fi
 
     - name: Run release-it


### PR DESCRIPTION
## Summary
- Fall back to `npm install` when no lockfile exists in the working directory
- Prevents `npm ci` from walking up to root and running from wrong location

Fixes #21

## Test plan
- [ ] Test with package that has no lockfile (like eslint-plugin-ui)
- [ ] Verify npm install runs instead of npm ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)